### PR TITLE
PHP 8.1 support

### DIFF
--- a/Decimal.php
+++ b/Decimal.php
@@ -463,5 +463,5 @@ final class Decimal implements \JsonSerializable
      *
      * @return string
      */
-    public function jsonSerialize() {}
+    public function jsonSerialize(): string {}
 }


### PR DESCRIPTION
PHP 8.1 adds a depreciation error if you don't specify the return type on the `Decimal::jsonSerialize` method definition.