### PR TITLE
Fix return type in PHP 8.2

### DIFF
--- a/Decimal.php
+++ b/Decimal.php
@@ -463,5 +463,5 @@ final class Decimal implements \JsonSerializable
      *
      * @return string
      */
-    public function jsonSerialize() {}
+    public function jsonSerialize(): mixed {}
 }


### PR DESCRIPTION
PHP 8.2 throws a fatal error because the interface nows declares a `mixed` return type.